### PR TITLE
Move to cask-fonts

### DIFF
--- a/laptop.local
+++ b/laptop.local
@@ -34,7 +34,7 @@ cask "skype"
 cask "sourcetree"
 cask "vlc"
 
-tap "caskroom/fonts"
+tap "homebrew/cask-fonts"
 cask "font-fira-code"
 
 mas "Patterns", id: 429449079


### PR DESCRIPTION
This seems to be the better source for homebrew fonts, which somehow was also tapped on my system.